### PR TITLE
Update closure-library submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/benvanik/google-closure-compiler-bin.git
 [submodule "third_party/closure-library"]
 	path = third_party/closure-library
-	url = https://code.google.com/p/closure-library/
+	url = https://github.com/google/closure-library/
 [submodule "third_party/closure-linter"]
 	path = third_party/closure-linter
 	url = https://github.com/knutwalker/google-closure-linter.git


### PR DESCRIPTION
The existing submodule URL for the closure library (`https://code.google.com/p/closure-library/`) will not resolve when doing a recursive clone (git won't follow the 301 redirect). This commit updates the URL to point to the library's new location on github. Similar to a [change](https://github.com/GoogleChrome/accessibility-developer-tools/pull/292/files) made in another Google repository that ran into the same problem.