### PR TITLE
Add eslint packages

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,26 @@
+{
+  "env": {
+    "browser": true,
+    "es2020": true,
+    "jasmine": true
+  },
+  "extends": [
+    "closure-es6",
+    "plugin:jasmine/recommended",
+    "google"
+  ],
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true
+    },
+    "ecmaVersion": 11,
+    "sourceType": "module"
+  },
+  "plugins": [
+    "jasmine",
+    "closure"
+  ],
+  "rules": {
+    "prefer-rest-params": "off"
+  }
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "env": {
     "browser": true,
-    "es2020": true,
+    "es6": true,
     "jasmine": true
   },
   "extends": [
@@ -10,10 +10,6 @@
     "google"
   ],
   "parserOptions": {
-    "ecmaFeatures": {
-      "jsx": true
-    },
-    "ecmaVersion": 11,
     "sourceType": "module"
   },
   "plugins": [

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,17 +19,6 @@ module.exports = function(grunt) {
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
 
-    closureLint: {
-      app:{
-        closureLinterPath : 'third_party/closure-linter/closure_linter',
-        src: ['src/**/*.js'],
-        options: {
-          stdout: true,
-          strict: true
-        }
-      }
-    },
-
     closureDepsWriter: {
       options: {
         closureLibraryPath: 'third_party/closure-library',
@@ -64,11 +53,9 @@ module.exports = function(grunt) {
   });
 
   grunt.loadNpmTasks('grunt-closure-tools');
-  grunt.loadNpmTasks('grunt-closure-linter');
   grunt.loadNpmTasks('grunt-contrib-qunit');
 
   grunt.registerTask('default', [
-    'closureLint',
     'closureDepsWriter',
     'closureBuilder',
     'qunit'

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "eslint-config-google": "^0.14.0",
     "eslint-plugin-jasmine": "^4.1.1",
     "grunt": "~0.4.1",
-    "grunt-closure-linter": "~0.1.0",
     "grunt-closure-tools": "~0.8.3",
     "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-jshint": "~0.6.0",

--- a/package.json
+++ b/package.json
@@ -2,14 +2,18 @@
   "name": "data-layer-helper",
   "version": "0.1.0",
   "devDependencies": {
+    "eslint": "^7.3.1",
+    "eslint-config-closure-es6": "^0.1.1",
+    "eslint-config-google": "^0.14.0",
+    "eslint-plugin-jasmine": "^4.1.1",
     "grunt": "~0.4.1",
+    "grunt-closure-linter": "~0.1.0",
+    "grunt-closure-tools": "~0.8.3",
+    "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-jshint": "~0.6.0",
     "grunt-contrib-nodeunit": "~0.2.0",
-    "grunt-contrib-uglify": "~0.2.2",
     "grunt-contrib-qunit": "~0.2.2",
-    "grunt-contrib-watch": "~0.4.4",
-    "grunt-contrib-concat": "~0.3.0",
-    "grunt-closure-tools": "~0.8.3",
-    "grunt-closure-linter": "~0.1.0"
+    "grunt-contrib-uglify": "~0.2.2",
+    "grunt-contrib-watch": "~0.4.4"
   }
 }


### PR DESCRIPTION
Set up a linter for the development environment for now. It's not the closure compiler linter exactly, but it should help to catch a lot of errors before compilation time, and it will be a good substitute until we can get the closure linter working.