### PR TITLE
Update to es6

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,7 @@
     "closure"
   ],
   "rules": {
-    "prefer-rest-params": "off"
+    "prefer-rest-params": "off",
+    "prefer-spread": "off"
   }
 }

--- a/src/helper/helper.js
+++ b/src/helper/helper.js
@@ -48,163 +48,171 @@ goog.provide('helper');
 goog.require('plain');
 
 
-
 /**
- * Creates a new helper object for the given dataLayer.
+ * A helper that will listen for new messages on the given dataLayer.
+ * Each new message will be merged into the helper's "abstract data model".
+ * This internal model object holds the most recent value for all keys which
+ * have been set on messages processed by the helper.
  *
- * @constructor
- * @param {!Array.<!Object>} dataLayer The dataLayer to help with.
- * @param {function(!Object, !Object)=} opt_listener The callback function to
- *     execute when a new state gets pushed onto the dataLayer.
- * @param {boolean=} opt_listenToPast If true, the given listener will be
- *     executed for state changes that have already happened.
+ * You can retrieve values from the data model by using the helper's get method.
  */
-helper.DataLayerHelper = function(dataLayer, opt_listener, opt_listenToPast) {
+class DataLayerHelper {
+  /**
+   * Creates a new helper object for the given dataLayer.
+   *
+   * @constructor
+   * @param {!Array.<!Object>} dataLayer The dataLayer to help with.
+   * @param {function(!Object, !Object)=} optListener The callback function to
+   *     execute when a new state gets pushed onto the dataLayer.
+   * @param {boolean=} optListenToPast If true, the given listener will be
+   *     executed for state changes that have already happened.
+   */
+  constructor(dataLayer, optListener, optListenToPast) {
+    /**
+     * The dataLayer to help with.
+     * @type {!Array.<!Object>}
+     * @private
+     */
+    this.dataLayer_ = dataLayer;
+
+    /**
+     * The listener to notify of changes to the dataLayer.
+     * @type {function(!Object, !Object)}
+     * @private
+     */
+    this.listener_ = optListener || function() {};
+
+    /**
+     * The internal marker for checking if the listener is
+     * currently on the stack.
+     * @type {boolean}
+     * @private
+     */
+    this.executingListener_ = false;
+
+    /**
+     * The internal representation of the dataLayer's state at the time of the
+     * update currently being processed.
+     * @type {!Object}
+     * @private
+     */
+    this.model_ = {};
+
+    /**
+     * The internal queue of dataLayer updates that have not yet been processed.
+     * @type {Array.<Object>}
+     * @private
+     */
+    this.unprocessed_ = [];
+
+    /**
+     * The interface to the internal dataLayer model that is exposed to custom
+     * methods. Custom methods will the executed with this interface as the
+     * value of 'this', allowing users to manipulate the model using this.get
+     * and this.set.
+     * @type {!Object}
+     * @private
+     */
+    this.abstractModelInterface_ = helper.buildAbstractModelInterface_(this);
+
+    // Process the existing/past states.
+    this.processStates_(dataLayer, !optListenToPast);
+
+    // Add listener for future state changes.
+    const oldPush = dataLayer.push;
+    const that = this;
+    dataLayer.push = function() {
+      const states = [].slice.call(arguments, 0);
+      const result = oldPush.apply(dataLayer, states);
+      that.processStates_(states);
+      return result;
+    };
+  }
 
   /**
-   * The dataLayer to help with.
-   * @type {!Array.<!Object>}
-   * @private
+   * Returns the value currently assigned to the given key in the helper's
+   * internal model.
+   *
+   * @param {string} key The path of the key to set on the model, where dot (.)
+   *     is the path separator.
+   * @return {*} The value found at the given key.
+   * @this {DataLayerHelper}
    */
-  this.dataLayer_ = dataLayer;
+  get(key) {
+    let target = this.model_;
+    const split = key.split('.');
+    for (let i = 0; i < split.length; i++) {
+      if (target[split[i]] === undefined) return undefined;
+      target = target[split[i]];
+    }
+    return target;
+  }
 
   /**
-   * The listener to notify of changes to the dataLayer.
-   * @type {function(!Object, !Object)}
-   * @private
+   * Flattens the dataLayer's history into a single object that represents the
+   * current state. This is useful for long running apps, where the dataLayer's
+   * history may get very large.
+   *
+   * @this {DataLayerHelper}
    */
-  this.listener_ = opt_listener || function() {};
+  flatten() {
+    this.dataLayer_.splice(0, this.dataLayer_.length);
+    this.dataLayer_[0] = {};
+    helper.merge_(this.model_, this.dataLayer_[0]);
+  }
 
   /**
-   * The internal marker for checking if the listener is currently on the stack.
-   * @type {boolean}
+   * Merges the given update objects (states) onto the helper's model, calling
+   * the listener each time the model is updated. If a command array is pushed
+   * into the dataLayer, the method will be parsed and applied to the value
+   * found at the key, if a one exists.
+   *
+   * @param {Array.<Object>} states The update objects to process, each
+   *     representing a change to the state of the page.
+   * @param {boolean=} optSkipListener If true, the listener the given states
+   *     will be applied to the internal model, but will not cause the listener
+   *     to be executed. This is useful for processing past states that the
+   *     listener might not care about.
    * @private
    */
-  this.executingListener_ = false;
-
-  /**
-   * The internal representation of the dataLayer's state at the time of the
-   * update currently being processed.
-   * @type {!Object}
-   * @private
-   */
-  this.model_ = {};
-
-  /**
-   * The internal queue of dataLayer updates that have not yet been processed.
-   * @type {Array.<Object>}
-   * @private
-   */
-  this.unprocessed_ = [];
-
-  /**
-   * The interface to the internal dataLayer model that is exposed to custom
-   * methods. Custom methods will the executed with this interface as the value
-   * of 'this', allowing users to manipulate the model using this.get and
-   * this.set.
-   * @type {!Object}
-   * @private
-   */
-  this.abstractModelInterface_ = helper.buildAbstractModelInterface_(this);
-
-  // Process the existing/past states.
-  this.processStates_(dataLayer, !opt_listenToPast);
-
-  // Add listener for future state changes.
-  var oldPush = dataLayer.push;
-  var that = this;
-  dataLayer.push = function() {
-    var states = [].slice.call(arguments, 0);
-    var result = oldPush.apply(dataLayer, states);
-    that.processStates_(states);
-    return result;
-  };
-};
+  processStates_(states, optSkipListener) {
+    this.unprocessed_.push.apply(this.unprocessed_, states);
+    // Checking executingListener here protects against multiple levels of
+    // loops trying to process the same queue. This can happen if the listener
+    // itself is causing new states to be pushed onto the dataLayer.
+    while (this.executingListener_ === false && this.unprocessed_.length > 0) {
+      const update = this.unprocessed_.shift();
+      if (helper.isArray_(update)) {
+        helper.processCommand_(update, this.model_);
+      } else if (typeof update == 'function') {
+        try {
+          update.call(this.abstractModelInterface_);
+        } catch (e) {
+          // Catch any exceptions to we don't drop subsequent updates.
+          // TODO: Add some sort of logging when this happens.
+        }
+      } else if (plain.isPlainObject(update)) {
+        for (const key in update) {
+          if (Object.prototype.hasOwnProperty.call(update, key)) {
+            helper.merge_(
+                helper.expandKeyValue_(key, update[key]),
+                this.model_
+            );
+          }
+        }
+      } else {
+        continue;
+      }
+      if (!optSkipListener) {
+        this.executingListener_ = true;
+        this.listener_(this.model_, update);
+        this.executingListener_ = false;
+      }
+    }
+  }
+}
+helper.DataLayerHelper = DataLayerHelper;
 window['DataLayerHelper'] = helper.DataLayerHelper;
-
-
-/**
- * Returns the value currently assigned to the given key in the helper's
- * internal model.
- *
- * @param {string} key The path of the key to set on the model, where dot (.)
- *     is the path separator.
- * @return {*} The value found at the given key.
- * @this {DataLayerHelper}
- */
-helper.DataLayerHelper.prototype['get'] = function(key) {
-  var target = this.model_;
-  var split = key.split('.');
-  for (var i = 0; i < split.length; i++) {
-    if (target[split[i]] === undefined) return undefined;
-    target = target[split[i]];
-  }
-  return target;
-};
-
-
-/**
- * Flattens the dataLayer's history into a single object that represents the
- * current state. This is useful for long running apps, where the dataLayer's
- * history may get very large.
- *
- * @this {DataLayerHelper}
- */
-helper.DataLayerHelper.prototype['flatten'] = function() {
-  this.dataLayer_.splice(0, this.dataLayer_.length);
-  this.dataLayer_[0] = {};
-  helper.merge_(this.model_, this.dataLayer_[0]);
-};
-
-
-/**
- * Merges the given update objects (states) onto the helper's model, calling
- * the listener each time the model is updated. If a command array is pushed
- * into the dataLayer, the method will be parsed and applied to the value found
- * at the key, if a one exists.
- *
- * @param {Array.<Object>} states The update objects to process, each
- *     representing a change to the state of the page.
- * @param {boolean=} opt_skipListener If true, the listener the given states
- *     will be applied to the internal model, but will not cause the listener
- *     to be executed. This is useful for processing past states that the
- *     listener might not care about.
- * @private
- */
-helper.DataLayerHelper.prototype.processStates_ =
-    function(states, opt_skipListener) {
-
-  this.unprocessed_.push.apply(this.unprocessed_, states);
-  // Checking executingListener here protects against multiple levels of
-  // loops trying to process the same queue. This can happen if the listener
-  // itself is causing new states to be pushed onto the dataLayer.
-  while (this.executingListener_ === false && this.unprocessed_.length > 0) {
-    var update = this.unprocessed_.shift();
-    if (helper.isArray_(update)) {
-      helper.processCommand_(update, this.model_);
-    } else if (typeof update == 'function') {
-      var that = this;
-      try {
-        update.call(this.abstractModelInterface_);
-      } catch (e) {
-        // Catch any exceptions to we don't drop subsequent updates.
-        // TODO: Add some sort of logging when this happens.
-      }
-    } else if (plain.isPlainObject(update)) {
-      for (var key in update) {
-        helper.merge_(helper.expandKeyValue_(key, update[key]), this.model_);
-      }
-    } else {
-      continue;
-    }
-    if (!opt_skipListener) {
-      this.executingListener_ = true;
-      this.listener_(this.model_, update);
-      this.executingListener_ = false;
-    }
-  }
-};
-
 
 /**
  * Helper function that will build the abstract model interface using the
@@ -218,16 +226,15 @@ helper.DataLayerHelper.prototype.processStates_ =
  */
 helper.buildAbstractModelInterface_ = function(dataLayerHelper) {
   return {
-    'set': function(key, value) {
+    set(key, value) {
       helper.merge_(helper.expandKeyValue_(key, value),
           dataLayerHelper.model_);
     },
-    'get': function(key) {
+    get(key) {
       return dataLayerHelper.get(key);
-    }
+    },
   };
 };
-
 
 /**
  * Applies the given method to the value in the dataLayer with the given key.
@@ -241,11 +248,11 @@ helper.buildAbstractModelInterface_ = function(dataLayerHelper) {
  */
 helper.processCommand_ = function(command, model) {
   if (!helper.isString_(command[0])) return;
-  var path = command[0].split('.');
-  var method = path.pop();
-  var args = command.slice(1);
-  var target = model;
-  for (var i = 0; i < path.length; i++) {
+  const path = command[0].split('.');
+  const method = path.pop();
+  const args = command.slice(1);
+  let target = model;
+  for (let i = 0; i < path.length; i++) {
     if (target[path[i]] === undefined) return;
     target = target[path[i]];
   }
@@ -256,7 +263,6 @@ helper.processCommand_ = function(command, model) {
     // TODO: Add some sort of logging here when this happens.
   }
 };
-
 
 /**
  * Converts the given key value pair into an object that can be merged onto
@@ -276,16 +282,15 @@ helper.processCommand_ = function(command, model) {
  * @private
  */
 helper.expandKeyValue_ = function(key, value) {
-  var result = {};
-  var target = result;
-  var split = key.split('.');
-  for (var i = 0; i < split.length - 1; i++) {
+  const result = {};
+  let target = result;
+  const split = key.split('.');
+  for (let i = 0; i < split.length - 1; i++) {
     target = target[split[i]] = {};
   }
   target[split[split.length - 1]] = value;
   return result;
 };
-
 
 /**
  * Determines if the given value is an array.
@@ -298,7 +303,6 @@ helper.isArray_ = function(value) {
   return plain.type(value) == 'array';
 };
 
-
 /**
  * Determines if the given value is a string.
  *
@@ -309,7 +313,6 @@ helper.isArray_ = function(value) {
 helper.isString_ = function(value) {
   return plain.type(value) == 'string';
 };
-
 
 /**
  * Merges one object into another or one array into another. Scalars and
@@ -325,9 +328,9 @@ helper.isString_ = function(value) {
  * @private
  */
 helper.merge_ = function(from, to) {
-  for (var property in from) {
+  for (const property in from) {
     if (plain.hasOwn(from, property)) {
-      var fromProperty = from[property];
+      const fromProperty = from[property];
       if (helper.isArray_(fromProperty)) {
         if (!helper.isArray_(to[property])) to[property] = [];
         helper.merge_(fromProperty, to[property]);
@@ -340,4 +343,3 @@ helper.merge_ = function(from, to) {
     }
   }
 };
-

--- a/src/helper/helper.js
+++ b/src/helper/helper.js
@@ -67,7 +67,7 @@ class DataLayerHelper {
    * @param {boolean=} optListenToPast If true, the given listener will be
    *     executed for state changes that have already happened.
    */
-  constructor(dataLayer, optListener, optListenToPast) {
+  constructor(dataLayer, optListener = () => {}, optListenToPast = false) {
     /**
      * The dataLayer to help with.
      * @type {!Array.<!Object>}
@@ -80,7 +80,7 @@ class DataLayerHelper {
      * @type {function(!Object, !Object)}
      * @private
      */
-    this.listener_ = optListener || function() {};
+    this.listener_ = optListener;
 
     /**
      * The internal marker for checking if the listener is
@@ -175,7 +175,7 @@ class DataLayerHelper {
    *     listener might not care about.
    * @private
    */
-  processStates_(states, optSkipListener) {
+  processStates_(states, optSkipListener = false) {
     this.unprocessed_.push.apply(this.unprocessed_, states);
     // Checking executingListener here protects against multiple levels of
     // loops trying to process the same queue. This can happen if the listener

--- a/src/helper/helper.js
+++ b/src/helper/helper.js
@@ -60,7 +60,6 @@ class DataLayerHelper {
   /**
    * Creates a new helper object for the given dataLayer.
    *
-   * @constructor
    * @param {!Array.<!Object>} dataLayer The dataLayer to help with.
    * @param {function(!Object, !Object)=} optListener The callback function to
    *     execute when a new state gets pushed onto the dataLayer.
@@ -100,7 +99,7 @@ class DataLayerHelper {
 
     /**
      * The internal queue of dataLayer updates that have not yet been processed.
-     * @type {Array.<Object>}
+     * @type {!Array.<!Object>}
      * @private
      */
     this.unprocessed_ = [];
@@ -136,7 +135,6 @@ class DataLayerHelper {
    * @param {string} key The path of the key to set on the model, where dot (.)
    *     is the path separator.
    * @return {*} The value found at the given key.
-   * @this {DataLayerHelper}
    */
   get(key) {
     let target = this.model_;
@@ -152,8 +150,6 @@ class DataLayerHelper {
    * Flattens the dataLayer's history into a single object that represents the
    * current state. This is useful for long running apps, where the dataLayer's
    * history may get very large.
-   *
-   * @this {DataLayerHelper}
    */
   flatten() {
     this.dataLayer_.splice(0, this.dataLayer_.length);
@@ -167,7 +163,7 @@ class DataLayerHelper {
    * into the dataLayer, the method will be parsed and applied to the value
    * found at the key, if a one exists.
    *
-   * @param {Array.<Object>} states The update objects to process, each
+   * @param {!Array.<!Object>} states The update objects to process, each
    *     representing a change to the state of the page.
    * @param {boolean=} optSkipListener If true, the listener the given states
    *     will be applied to the internal model, but will not cause the listener
@@ -218,9 +214,9 @@ window['DataLayerHelper'] = helper.DataLayerHelper;
  * Helper function that will build the abstract model interface using the
  * supplied dataLayerHelper.
  *
- * @param {DataLayerHelper} dataLayerHelper The helper class to construct the
+ * @param {!DataLayerHelper} dataLayerHelper The helper class to construct the
  *     abstract model interface for.
- * @return {Object} The interface to the abstract data layer model that is given
+ * @return {!Object} The interface to the abstract data layer model that is given
  *     to Custom Methods.
  * @private
  */
@@ -241,9 +237,9 @@ helper.buildAbstractModelInterface_ = function(dataLayerHelper) {
  * If the method is a valid function of the value, the method will be applies
  * with any arguments passed in.
  *
- * @param {Array.<Object>} command The array containing the key with the
+ * @param {!Array.<!Object>} command The array containing the key with the
  *     method to execute and optional arguments for the method.
- * @param {Object|Array} model The current dataLayer model.
+ * @param {!Object|!Array} model The current dataLayer model.
  * @private
  */
 helper.processCommand_ = function(command, model) {
@@ -277,7 +273,7 @@ helper.processCommand_ = function(command, model) {
  *
  * @param {string} key The key's path, where dots are the path separators.
  * @param {*} value The value to set on the given key path.
- * @return {Object} An object representing the given key/value which can be
+ * @return {!Object} An object representing the given key/value which can be
  *     merged onto the dataLayer's model.
  * @private
  */
@@ -323,8 +319,8 @@ helper.isString_ = function(value) {
  * objects get cloned and which get copied. More work is needed to flesh
  * out the details here.
  *
- * @param {Object|Array} from The object or array to merge from.
- * @param {Object|Array} to The object or array to merge into.
+ * @param {!Object|!Array} from The object or array to merge from.
+ * @param {!Object|!Array} to The object or array to merge into.
  * @private
  */
 helper.merge_ = function(from, to) {

--- a/src/helper/helper.js
+++ b/src/helper/helper.js
@@ -60,7 +60,7 @@ class DataLayerHelper {
   /**
    * Creates a new helper object for the given dataLayer.
    *
-   * @param {!Array.<!Object>} dataLayer The dataLayer to help with.
+   * @param {!Array<!Object>} dataLayer The dataLayer to help with.
    * @param {function(!Object, !Object)=} optListener The callback function to
    *     execute when a new state gets pushed onto the dataLayer.
    * @param {boolean=} optListenToPast If true, the given listener will be
@@ -69,7 +69,7 @@ class DataLayerHelper {
   constructor(dataLayer, optListener = () => {}, optListenToPast = false) {
     /**
      * The dataLayer to help with.
-     * @type {!Array.<!Object>}
+     * @type {!Array<!Object>}
      * @private
      */
     this.dataLayer_ = dataLayer;
@@ -99,7 +99,7 @@ class DataLayerHelper {
 
     /**
      * The internal queue of dataLayer updates that have not yet been processed.
-     * @type {!Array.<!Object>}
+     * @type {!Array<!Object>}
      * @private
      */
     this.unprocessed_ = [];
@@ -163,7 +163,7 @@ class DataLayerHelper {
    * into the dataLayer, the method will be parsed and applied to the value
    * found at the key, if a one exists.
    *
-   * @param {!Array.<!Object>} states The update objects to process, each
+   * @param {!Array<!Object>} states The update objects to process, each
    *     representing a change to the state of the page.
    * @param {boolean=} optSkipListener If true, the listener the given states
    *     will be applied to the internal model, but will not cause the listener
@@ -237,7 +237,7 @@ helper.buildAbstractModelInterface_ = function(dataLayerHelper) {
  * If the method is a valid function of the value, the method will be applies
  * with any arguments passed in.
  *
- * @param {!Array.<!Object>} command The array containing the key with the
+ * @param {!Array<!Object>} command The array containing the key with the
  *     method to execute and optional arguments for the method.
  * @param {!Object|!Array} model The current dataLayer model.
  * @private

--- a/src/helper/helper.js
+++ b/src/helper/helper.js
@@ -178,9 +178,7 @@ class DataLayerHelper {
     // itself is causing new states to be pushed onto the dataLayer.
     while (this.executingListener_ === false && this.unprocessed_.length > 0) {
       const update = this.unprocessed_.shift();
-      if (helper.isArray_(update)) {
-        helper.processCommand_(update, this.model_);
-      } else if (typeof update == 'function') {
+      if (typeof update == 'function') {
         try {
           update.call(this.abstractModelInterface_);
         } catch (e) {

--- a/src/plain/is_plain_object.js
+++ b/src/plain/is_plain_object.js
@@ -23,7 +23,6 @@ goog.provide('plain');
 plain.TYPE_RE_ =
     /\[object (Boolean|Number|String|Function|Array|Date|RegExp)\]/;
 
-
 /**
  * Returns a string describing the given value's type. Same as typeof, except
  * in these cases (assuming the value's typeof() method has not been modified):
@@ -46,12 +45,11 @@ plain.TYPE_RE_ =
  */
 plain.type = function(value) {
   if (value == null) return String(value);
-  var match = plain.TYPE_RE_.exec(
+  const match = plain.TYPE_RE_.exec(
       Object.prototype.toString.call(Object(value)));
   if (match) return match[1].toLowerCase();
   return 'object';
 };
-
 
 /**
  * Determines if the value has a non-inherited property with the given key.
@@ -64,7 +62,6 @@ plain.hasOwn = function(value, key) {
   return Object.prototype.hasOwnProperty.call(Object(value), key);
 };
 
-
 /**
  * Determines if the given value is a "plain" object, meaning it's an object
  * with no inherited properties that isn't a null, date, regexp, array,
@@ -74,9 +71,9 @@ plain.hasOwn = function(value, key) {
  * @return {boolean} True iff the given value is a "plain" object.
  */
 plain.isPlainObject = function(value) {
-  if (!value || plain.type(value) != 'object' ||    // Nulls, dates, etc.
-      value.nodeType ||                             // DOM nodes.
-      value == value.window) {                      // Window objects.
+  if (!value || plain.type(value) != 'object' || // Nulls, dates, etc.
+      value.nodeType || // DOM nodes.
+      value == value.window) { // Window objects.
     return false;
   }
   try {
@@ -96,8 +93,7 @@ plain.isPlainObject = function(value) {
   // Lastly, we check that all properties are non-inherited.
   // According to jQuery, inherited properties are always enumerated last, so
   // it's safe to only check the last enumerated property.
-  var key;
+  let key;
   for (key in value) {}
   return key === undefined || plain.hasOwn(value, key);
 };
-

--- a/src/plain/is_plain_object.js
+++ b/src/plain/is_plain_object.js
@@ -16,7 +16,7 @@ goog.provide('plain');
 
 /**
  * Pattern used by plain.type to match [object XXX] strings.
- * @type {RegExp}
+ * @type {!RegExp}
  * @private
  * @const
  */


### PR DESCRIPTION
- [Changes variables to const / let](https://google.github.io/styleguide/jsguide.html#features-use-const-and-let)

- [Utilizes class syntax for DataLayerHelper](https://google.github.io/styleguide/jsguide.html#features-classes)

- [Fixes several JSDoc types to use explicit non nullability where appropriate](https://google.github.io/styleguide/jsguide.html#jsdoc-nullability)

- [Adds method shorthands to buildAbstractModelInterface_ function](https://google.github.io/styleguide/jsguide.html#features-objects-method-shorthand)

- Adds recommended check for Object key existing as per [linter recommendation](https://eslint.org/docs/rules/guard-for-in)

- Removes unreachable code that gave type error in processStates_ function.