### PR TITLE
Add small es6 improvements

### DIFF
--- a/src/helper/helper.js
+++ b/src/helper/helper.js
@@ -54,8 +54,8 @@ const {type, hasOwn, isPlainObject} = goog.require('plain');
  *
  * @constructor
  * @param {!Array<*>} dataLayer The dataLayer to help with.
- * @param {function(!Object, !Object)=} optListener The callback function to
- *     execute when a new state gets pushed onto the dataLayer.
+ * @param {function(!Object<*,*>, !Object<*,*>)=} optListener The callback
+ *     function to execute when a new state gets pushed onto the dataLayer.
  * @param {boolean=} optListenToPast If true, the given listener will be
  *     executed for state changes that have already happened.
  */
@@ -69,7 +69,7 @@ const DataLayerHelper = function(dataLayer, optListener = () => {}, optListenToP
 
   /**
    * The listener to notify of changes to the dataLayer.
-   * @type {function(!Object, !Object)}
+   * @type {function(!Object<*,*>, !Object<*,*>)}
    * @private
    */
   this.listener_ = optListener;
@@ -85,7 +85,7 @@ const DataLayerHelper = function(dataLayer, optListener = () => {}, optListenToP
   /**
    * The internal representation of the dataLayer's state at the time of the
    * update currently being processed.
-   * @type {!Object}
+   * @type {!Object<*,*>}
    * @private
    */
   this.model_ = {};
@@ -102,7 +102,7 @@ const DataLayerHelper = function(dataLayer, optListener = () => {}, optListenToP
    * methods. Custom methods will the executed with this interface as the
    * value of 'this', allowing users to manipulate the model using this.get
    * and this.set.
-   * @type {!Object}
+   * @type {!Object<*,*>}
    * @private
    */
   this.abstractModelInterface_ = buildAbstractModelInterface_(this);
@@ -171,7 +171,8 @@ DataLayerHelper.prototype['flatten'] = function() {
  *     listener might not care about.
  * @private
  */
-processStates_(states, optSkipListener = false) {
+DataLayerHelper.prototype.processStates_ =
+    function(states, optSkipListener = false) {
   this.unprocessed_.push.apply(this.unprocessed_, states);
   // Checking executingListener here protects against multiple levels of
   // loops trying to process the same queue. This can happen if the listener
@@ -212,7 +213,7 @@ processStates_(states, optSkipListener = false) {
  *
  * @param {!DataLayerHelper} dataLayerHelper The helper class to construct the
  *     abstract model interface for.
- * @return {!Object} The interface to the abstract data layer model that is
+ * @return {!Object<*,*>} The interface to the abstract data layer model that is
  *     given to Custom Methods.
  * @private
  */
@@ -236,7 +237,7 @@ function buildAbstractModelInterface_(dataLayerHelper) {
  *
  * @param {!Array<*>} command The array containing the key with the
  *     method to execute and optional arguments for the method.
- * @param {!Object|!Array} model The current dataLayer model.
+ * @param {!Object<*,*>|!Array<*>} model The current dataLayer model.
  * @private
  */
 function processCommand_(command, model) {
@@ -262,14 +263,14 @@ function processCommand_(command, model) {
  * If a processor for the command has been registered, the processor function
  * will be invoked with any arguments passed in.
  *
- * @param {Array.<Object>} args The arguments object containing the command
+ * @param {!Array<*>} args The arguments object containing the command
  *     to execute and optional arguments for the processor.
- * @param {Object|Array} model The current dataLayer model.
+ * @param {!Object<*,*>|!Array<*>} model The current dataLayer model.
  * @private
  */
 function processArguments_(args, model) {
-  //TODO: add process command code
-};
+  // TODO: add process command code
+}
 
 /**
  * Converts the given key value pair into an object that can be merged onto
@@ -284,7 +285,7 @@ function processArguments_(args, model) {
  *
  * @param {string} key The key's path, where dots are the path separators.
  * @param {*} value The value to set on the given key path.
- * @return {!Object} An object representing the given key/value which can be
+ * @return {!Object<*,*>} An object representing the given key/value which can be
  *     merged onto the dataLayer's model.
  * @private
  */
@@ -344,8 +345,8 @@ function isString_(value) {
  * objects get cloned and which get copied. More work is needed to flesh
  * out the details here.
  *
- * @param {!Object|!Array} from The object or array to merge from.
- * @param {!Object|!Array} to The object or array to merge into.
+ * @param {!Object<*,*>|!Array<*>} from The object or array to merge from.
+ * @param {!Object<*,*>|!Array<*>} to The object or array to merge into.
  * @private
  */
 function merge_(from, to) {

--- a/src/helper/helper.js
+++ b/src/helper/helper.js
@@ -59,8 +59,7 @@ const {type, hasOwn, isPlainObject} = goog.require('plain');
  * @param {boolean=} optListenToPast If true, the given listener will be
  *     executed for state changes that have already happened.
  */
-const DataLayerHelper = function(dataLayer, optListener, optListenToPast) {
-
+const DataLayerHelper = function(dataLayer, optListener = () => {}, optListenToPast = false) {
   /**
    * The dataLayer to help with.
    * @type {!Array<*>}
@@ -73,7 +72,7 @@ const DataLayerHelper = function(dataLayer, optListener, optListenToPast) {
    * @type {function(!Object, !Object)}
    * @private
    */
-  this.listener_ = optListener || function() {};
+  this.listener_ = optListener;
 
   /**
    * The internal marker for checking if the listener is currently on the stack.
@@ -171,9 +170,7 @@ DataLayerHelper.prototype['flatten'] = function() {
  *     listener might not care about.
  * @private
  */
-DataLayerHelper.prototype.processStates_ =
-    function(states, opt_skipListener) {
-
+processStates_(states, optSkipListener = false) {
   this.unprocessed_.push.apply(this.unprocessed_, states);
   // Checking executingListener here protects against multiple levels of
   // loops trying to process the same queue. This can happen if the listener
@@ -199,7 +196,7 @@ DataLayerHelper.prototype.processStates_ =
     } else {
       continue;
     }
-    if (!opt_skipListener) {
+    if (!optSkipListener) {
       this.executingListener_ = true;
       this.listener_(this.model_, update);
       this.executingListener_ = false;

--- a/src/helper/helper.js
+++ b/src/helper/helper.js
@@ -54,7 +54,7 @@ const {type, hasOwn, isPlainObject} = goog.require('plain');
  *
  * @constructor
  * @param {!Array<*>} dataLayer The dataLayer to help with.
- * @param {function(!Object<*,*>, !Object<*,*>)=} optListener The callback
+ * @param {function(!Object<*>, !Object<*>)=} optListener The callback
  *     function to execute when a new state gets pushed onto the dataLayer.
  * @param {boolean=} optListenToPast If true, the given listener will be
  *     executed for state changes that have already happened.
@@ -69,7 +69,7 @@ const DataLayerHelper = function(dataLayer, optListener = () => {}, optListenToP
 
   /**
    * The listener to notify of changes to the dataLayer.
-   * @type {function(!Object<*,*>, !Object<*,*>)}
+   * @type {function(!Object<*>, *)}
    * @private
    */
   this.listener_ = optListener;
@@ -85,7 +85,7 @@ const DataLayerHelper = function(dataLayer, optListener = () => {}, optListenToP
   /**
    * The internal representation of the dataLayer's state at the time of the
    * update currently being processed.
-   * @type {!Object<*,*>}
+   * @type {!Object<*>}
    * @private
    */
   this.model_ = {};
@@ -102,7 +102,7 @@ const DataLayerHelper = function(dataLayer, optListener = () => {}, optListenToP
    * methods. Custom methods will the executed with this interface as the
    * value of 'this', allowing users to manipulate the model using this.get
    * and this.set.
-   * @type {!Object<*,*>}
+   * @type {!Object<*>}
    * @private
    */
   this.abstractModelInterface_ = buildAbstractModelInterface_(this);
@@ -213,7 +213,7 @@ DataLayerHelper.prototype.processStates_ =
  *
  * @param {!DataLayerHelper} dataLayerHelper The helper class to construct the
  *     abstract model interface for.
- * @return {!Object<*,*>} The interface to the abstract data layer model that is
+ * @return {!Object<*>} The interface to the abstract data layer model that is
  *     given to Custom Methods.
  * @private
  */
@@ -235,9 +235,9 @@ function buildAbstractModelInterface_(dataLayerHelper) {
  * If the method is a valid function of the value, the method will be applies
  * with any arguments passed in.
  *
- * @param {!Array<*>} command The array containing the key with the
+ * @param {*} command The array containing the key with the
  *     method to execute and optional arguments for the method.
- * @param {!Object<*,*>|!Array<*>} model The current dataLayer model.
+ * @param {!Object<*>|!Array<*>} model The current dataLayer model.
  * @private
  */
 function processCommand_(command, model) {
@@ -263,9 +263,9 @@ function processCommand_(command, model) {
  * If a processor for the command has been registered, the processor function
  * will be invoked with any arguments passed in.
  *
- * @param {!Array<*>} args The arguments object containing the command
+ * @param {*} args The arguments object containing the command
  *     to execute and optional arguments for the processor.
- * @param {!Object<*,*>|!Array<*>} model The current dataLayer model.
+ * @param {!Object<*>|!Array<*>} model The current dataLayer model.
  * @private
  */
 function processArguments_(args, model) {
@@ -285,7 +285,7 @@ function processArguments_(args, model) {
  *
  * @param {string} key The key's path, where dots are the path separators.
  * @param {*} value The value to set on the given key path.
- * @return {!Object<*,*>} An object representing the given key/value which can be
+ * @return {!Object<*>} An object representing the given key/value which can be
  *     merged onto the dataLayer's model.
  * @private
  */
@@ -345,8 +345,8 @@ function isString_(value) {
  * objects get cloned and which get copied. More work is needed to flesh
  * out the details here.
  *
- * @param {!Object<*,*>|!Array<*>} from The object or array to merge from.
- * @param {!Object<*,*>|!Array<*>} to The object or array to merge into.
+ * @param {*} from The object or array to merge from.
+ * @param {*} to The object or array to merge into.
  * @private
  */
 function merge_(from, to) {

--- a/src/helper/helper.js
+++ b/src/helper/helper.js
@@ -53,7 +53,7 @@ const {type, hasOwn, isPlainObject} = goog.require('plain');
  * Creates a new helper object for the given dataLayer.
  *
  * @constructor
- * @param {!Array.<!Object>} dataLayer The dataLayer to help with.
+ * @param {!Array<*>} dataLayer The dataLayer to help with.
  * @param {function(!Object, !Object)=} optListener The callback function to
  *     execute when a new state gets pushed onto the dataLayer.
  * @param {boolean=} optListenToPast If true, the given listener will be
@@ -63,7 +63,7 @@ const DataLayerHelper = function(dataLayer, optListener, optListenToPast) {
 
   /**
    * The dataLayer to help with.
-   * @type {!Array.<!Object>}
+   * @type {!Array<*>}
    * @private
    */
   this.dataLayer_ = dataLayer;
@@ -92,7 +92,7 @@ const DataLayerHelper = function(dataLayer, optListener, optListenToPast) {
 
   /**
    * The internal queue of dataLayer updates that have not yet been processed.
-   * @type {Array.<Object>}
+   * @type {!Array<*>}
    * @private
    */
   this.unprocessed_ = [];
@@ -163,9 +163,9 @@ DataLayerHelper.prototype['flatten'] = function() {
  * into the dataLayer, the method will be parsed and applied to the value found
  * at the key, if a one exists.
  *
- * @param {Array.<Object>} states The update objects to process, each
+ * @param {!Array<*>} states The update objects to process, each
  *     representing a change to the state of the page.
- * @param {boolean=} opt_skipListener If true, the listener the given states
+ * @param {boolean=} optSkipListener If true, the listener the given states
  *     will be applied to the internal model, but will not cause the listener
  *     to be executed. This is useful for processing past states that the
  *     listener might not care about.
@@ -212,9 +212,9 @@ DataLayerHelper.prototype.processStates_ =
  * Helper function that will build the abstract model interface using the
  * supplied dataLayerHelper.
  *
- * @param {DataLayerHelper} dataLayerHelper The helper class to construct the
+ * @param {!DataLayerHelper} dataLayerHelper The helper class to construct the
  *     abstract model interface for.
- * @return {Object} The interface to the abstract data layer model that is given
+ * @return {!Object} The interface to the abstract data layer model that is given
  *     to Custom Methods.
  * @private
  */
@@ -236,9 +236,9 @@ function buildAbstractModelInterface_(dataLayerHelper) {
  * If the method is a valid function of the value, the method will be applies
  * with any arguments passed in.
  *
- * @param {Array.<Object>} command The array containing the key with the
+ * @param {!Array<*>} command The array containing the key with the
  *     method to execute and optional arguments for the method.
- * @param {Object|Array} model The current dataLayer model.
+ * @param {!Object|!Array} model The current dataLayer model.
  * @private
  */
 function processCommand_(command, model) {
@@ -286,7 +286,7 @@ function processArguments_(args, model) {
  *
  * @param {string} key The key's path, where dots are the path separators.
  * @param {*} value The value to set on the given key path.
- * @return {Object} An object representing the given key/value which can be
+ * @return {!Object} An object representing the given key/value which can be
  *     merged onto the dataLayer's model.
  * @private
  */
@@ -346,8 +346,8 @@ function isString_(value) {
  * objects get cloned and which get copied. More work is needed to flesh
  * out the details here.
  *
- * @param {Object|Array} from The object or array to merge from.
- * @param {Object|Array} to The object or array to merge into.
+ * @param {!Object|!Array} from The object or array to merge from.
+ * @param {!Object|!Array} to The object or array to merge into.
  * @private
  */
 function merge_(from, to) {

--- a/src/helper/helper.js
+++ b/src/helper/helper.js
@@ -153,7 +153,7 @@ DataLayerHelper.prototype['get'] = function(key) {
 DataLayerHelper.prototype['flatten'] = function() {
   this.dataLayer_.splice(0, this.dataLayer_.length);
   this.dataLayer_[0] = {};
-  merge_(this.model_, this.dataLayer_[0]);
+  merge_(this.model_, /** @type {!Object<*>} */ (this.dataLayer_[0]));
 };
 
 
@@ -180,9 +180,9 @@ DataLayerHelper.prototype.processStates_ =
       while (this.executingListener_ === false && this.unprocessed_.length > 0) {
         const update = this.unprocessed_.shift();
         if (isArray_(update)) {
-          processCommand_(update, this.model_);
+          processCommand_(/** @type {!Array<*>} */ (update), this.model_);
         } else if (isArguments_(update)) {
-          processArguments_(update, this.model_);
+          processArguments_(/** @type {!Object<*>} */ (update), this.model_);
         } else if (typeof update == 'function') {
           try {
             update.call(this.abstractModelInterface_);
@@ -234,7 +234,7 @@ function buildAbstractModelInterface_(dataLayerHelper) {
  * If the method is a valid function of the value, the method will be applies
  * with any arguments passed in.
  *
- * @param {*} command The array containing the key with the
+ * @param {!Array<*>} command The array containing the key with the
  *     method to execute and optional arguments for the method.
  * @param {!Object<*>|!Array<*>} model The current dataLayer model.
  * @private
@@ -262,7 +262,7 @@ function processCommand_(command, model) {
  * If a processor for the command has been registered, the processor function
  * will be invoked with any arguments passed in.
  *
- * @param {*} args The arguments object containing the command
+ * @param {!Object<*>} args The arguments object containing the command
  *     to execute and optional arguments for the processor.
  * @param {!Object<*>|!Array<*>} model The current dataLayer model.
  * @private
@@ -344,8 +344,8 @@ function isString_(value) {
  * objects get cloned and which get copied. More work is needed to flesh
  * out the details here.
  *
- * @param {*} from The object or array to merge from.
- * @param {*} to The object or array to merge into.
+ * @param {!Array<*>|!Object<*>} from The object or array to merge from.
+ * @param {!Array<*>|!Object<*>} to The object or array to merge into.
  * @private
  */
 function merge_(from, to) {

--- a/src/helper/helper.js
+++ b/src/helper/helper.js
@@ -173,7 +173,7 @@ DataLayerHelper.prototype['flatten'] = function() {
  */
 DataLayerHelper.prototype.processStates_ =
     function(states, optSkipListener = false) {
-  this.unprocessed_.push.apply(this.unprocessed_, states);
+      this.unprocessed_.push.apply(this.unprocessed_, states);
       // Checking executingListener here protects against multiple levels of
       // loops trying to process the same queue. This can happen if the listener
       // itself is causing new states to be pushed onto the dataLayer.

--- a/src/helper/helper.js
+++ b/src/helper/helper.js
@@ -322,7 +322,7 @@ function isArray_(value) {
  */
 function isArguments_(value) {
   return type(value) === 'arguments';
-};
+}
 
 
 /**

--- a/src/helper/helper.js
+++ b/src/helper/helper.js
@@ -111,11 +111,11 @@ const DataLayerHelper = function(dataLayer, optListener = () => {}, optListenToP
   this.processStates_(dataLayer, !optListenToPast);
 
   // Add listener for future state changes.
-  var oldPush = dataLayer.push;
-  var that = this;
+  const oldPush = dataLayer.push;
+  const that = this;
   dataLayer.push = function() {
-    var states = [].slice.call(arguments, 0);
-    var result = oldPush.apply(dataLayer, states);
+    const states = [].slice.call(arguments, 0);
+    const result = oldPush.apply(dataLayer, states);
     that.processStates_(states);
     return result;
   };
@@ -133,9 +133,9 @@ window['DataLayerHelper'] = DataLayerHelper;
  * @this {DataLayerHelper}
  */
 DataLayerHelper.prototype['get'] = function(key) {
-  var target = this.model_;
-  var split = key.split('.');
-  for (var i = 0; i < split.length; i++) {
+  let target = this.model_;
+  const split = key.split('.');
+  for (let i = 0; i < split.length; i++) {
     if (target[split[i]] === undefined) return undefined;
     target = target[split[i]];
   }
@@ -178,7 +178,7 @@ DataLayerHelper.prototype.processStates_ =
   // loops trying to process the same queue. This can happen if the listener
   // itself is causing new states to be pushed onto the dataLayer.
   while (this.executingListener_ === false && this.unprocessed_.length > 0) {
-    var update = this.unprocessed_.shift();
+    const update = this.unprocessed_.shift();
     if (isArray_(update)) {
       processCommand_(update, this.model_);
     } else if (isArguments_(update)) {
@@ -242,11 +242,11 @@ function buildAbstractModelInterface_(dataLayerHelper) {
  */
 function processCommand_(command, model) {
   if (!isString_(command[0])) return;
-  var path = command[0].split('.');
-  var method = path.pop();
-  var args = command.slice(1);
-  var target = model;
-  for (var i = 0; i < path.length; i++) {
+  const path = command[0].split('.');
+  const method = path.pop();
+  const args = command.slice(1);
+  let target = model;
+  for (let i = 0; i < path.length; i++) {
     if (target[path[i]] === undefined) return;
     target = target[path[i]];
   }
@@ -290,10 +290,10 @@ function processArguments_(args, model) {
  * @private
  */
 function expandKeyValue_(key, value) {
-  var result = {};
-  var target = result;
-  var split = key.split('.');
-  for (var i = 0; i < split.length - 1; i++) {
+  const result = {};
+  let target = result;
+  const split = key.split('.');
+  for (let i = 0; i < split.length - 1; i++) {
     target = target[split[i]] = {};
   }
   target[split[split.length - 1]] = value;
@@ -350,9 +350,9 @@ function isString_(value) {
  * @private
  */
 function merge_(from, to) {
-  for (var property in from) {
+  for (const property in from) {
     if (hasOwn(from, property)) {
-      var fromProperty = from[property];
+      const fromProperty = from[property];
       if (isArray_(fromProperty)) {
         if (!isArray_(to[property])) to[property] = [];
         merge_(fromProperty, to[property]);

--- a/src/helper/helper.js
+++ b/src/helper/helper.js
@@ -236,7 +236,7 @@ function buildAbstractModelInterface_(dataLayerHelper) {
  *
  * @param {!Array<*>} command The array containing the key with the
  *     method to execute and optional arguments for the method.
- * @param {!Object<*>|!Array<*>} model The current dataLayer model.
+ * @param {!Object<*>} model The current dataLayer model.
  * @private
  */
 function processCommand_(command, model) {
@@ -264,7 +264,7 @@ function processCommand_(command, model) {
  *
  * @param {!Object<*>} args The arguments object containing the command
  *     to execute and optional arguments for the processor.
- * @param {!Object<*>|!Array<*>} model The current dataLayer model.
+ * @param {!Object<*>} model The current dataLayer model.
  * @private
  */
 function processArguments_(args, model) {

--- a/src/helper/helper.js
+++ b/src/helper/helper.js
@@ -75,7 +75,8 @@ const DataLayerHelper = function(dataLayer, optListener = () => {}, optListenToP
   this.listener_ = optListener;
 
   /**
-   * The internal marker for checking if the listener is currently on the stack.
+   * The internal marker for checking if the listener is
+   * currently on the stack.
    * @type {boolean}
    * @private
    */
@@ -98,9 +99,9 @@ const DataLayerHelper = function(dataLayer, optListener = () => {}, optListenToP
 
   /**
    * The interface to the internal dataLayer model that is exposed to custom
-   * methods. Custom methods will the executed with this interface as the value
-   * of 'this', allowing users to manipulate the model using this.get and
-   * this.set.
+   * methods. Custom methods will the executed with this interface as the
+   * value of 'this', allowing users to manipulate the model using this.get
+   * and this.set.
    * @type {!Object}
    * @private
    */
@@ -159,8 +160,8 @@ DataLayerHelper.prototype['flatten'] = function() {
 /**
  * Merges the given update objects (states) onto the helper's model, calling
  * the listener each time the model is updated. If a command array is pushed
- * into the dataLayer, the method will be parsed and applied to the value found
- * at the key, if a one exists.
+ * into the dataLayer, the method will be parsed and applied to the value
+ * found at the key, if a one exists.
  *
  * @param {!Array<*>} states The update objects to process, each
  *     representing a change to the state of the page.
@@ -211,8 +212,8 @@ processStates_(states, optSkipListener = false) {
  *
  * @param {!DataLayerHelper} dataLayerHelper The helper class to construct the
  *     abstract model interface for.
- * @return {!Object} The interface to the abstract data layer model that is given
- *     to Custom Methods.
+ * @return {!Object} The interface to the abstract data layer model that is
+ *     given to Custom Methods.
  * @private
  */
 function buildAbstractModelInterface_(dataLayerHelper) {

--- a/src/helper/helper.js
+++ b/src/helper/helper.js
@@ -174,36 +174,35 @@ DataLayerHelper.prototype['flatten'] = function() {
 DataLayerHelper.prototype.processStates_ =
     function(states, optSkipListener = false) {
   this.unprocessed_.push.apply(this.unprocessed_, states);
-  // Checking executingListener here protects against multiple levels of
-  // loops trying to process the same queue. This can happen if the listener
-  // itself is causing new states to be pushed onto the dataLayer.
-  while (this.executingListener_ === false && this.unprocessed_.length > 0) {
-    const update = this.unprocessed_.shift();
-    if (isArray_(update)) {
-      processCommand_(update, this.model_);
-    } else if (isArguments_(update)) {
-      processArguments_(update, this.model_);
-    } else if (typeof update == 'function') {
-      var that = this;
-      try {
-        update.call(this.abstractModelInterface_);
-      } catch (e) {
-        // Catch any exceptions to we don't drop subsequent updates.
-        // TODO: Add some sort of logging when this happens.
+      // Checking executingListener here protects against multiple levels of
+      // loops trying to process the same queue. This can happen if the listener
+      // itself is causing new states to be pushed onto the dataLayer.
+      while (this.executingListener_ === false && this.unprocessed_.length > 0) {
+        const update = this.unprocessed_.shift();
+        if (isArray_(update)) {
+          processCommand_(update, this.model_);
+        } else if (isArguments_(update)) {
+          processArguments_(update, this.model_);
+        } else if (typeof update == 'function') {
+          try {
+            update.call(this.abstractModelInterface_);
+          } catch (e) {
+            // Catch any exceptions to we don't drop subsequent updates.
+            // TODO: Add some sort of logging when this happens.
+          }
+        } else if (isPlainObject(update)) {
+          for (const key in update) {
+            merge_(expandKeyValue_(key, update[key]), this.model_);
+          }
+        } else {
+          continue;
+        }
+        if (!optSkipListener) {
+          this.executingListener_ = true;
+          this.listener_(this.model_, update);
+          this.executingListener_ = false;
+        }
       }
-    } else if (isPlainObject(update)) {
-      for (var key in update) {
-        merge_(expandKeyValue_(key, update[key]), this.model_);
-      }
-    } else {
-      continue;
-    }
-    if (!optSkipListener) {
-      this.executingListener_ = true;
-      this.listener_(this.model_, update);
-      this.executingListener_ = false;
-    }
-  }
 };
 
 

--- a/src/helper/helper.js
+++ b/src/helper/helper.js
@@ -219,13 +219,13 @@ DataLayerHelper.prototype.processStates_ =
  */
 function buildAbstractModelInterface_(dataLayerHelper) {
   return {
-    'set': function(key, value) {
+    set(key, value) {
       merge_(expandKeyValue_(key, value),
           dataLayerHelper.model_);
     },
-    'get': function(key) {
+    get(key) {
       return dataLayerHelper.get(key);
-    }
+    },
   };
 }
 

--- a/src/helper/helper.js
+++ b/src/helper/helper.js
@@ -54,12 +54,12 @@ const {type, hasOwn, isPlainObject} = goog.require('plain');
  *
  * @constructor
  * @param {!Array.<!Object>} dataLayer The dataLayer to help with.
- * @param {function(!Object, !Object)=} opt_listener The callback function to
+ * @param {function(!Object, !Object)=} optListener The callback function to
  *     execute when a new state gets pushed onto the dataLayer.
- * @param {boolean=} opt_listenToPast If true, the given listener will be
+ * @param {boolean=} optListenToPast If true, the given listener will be
  *     executed for state changes that have already happened.
  */
-const DataLayerHelper = function(dataLayer, opt_listener, opt_listenToPast) {
+const DataLayerHelper = function(dataLayer, optListener, optListenToPast) {
 
   /**
    * The dataLayer to help with.
@@ -73,7 +73,7 @@ const DataLayerHelper = function(dataLayer, opt_listener, opt_listenToPast) {
    * @type {function(!Object, !Object)}
    * @private
    */
-  this.listener_ = opt_listener || function() {};
+  this.listener_ = optListener || function() {};
 
   /**
    * The internal marker for checking if the listener is currently on the stack.
@@ -108,7 +108,7 @@ const DataLayerHelper = function(dataLayer, opt_listener, opt_listenToPast) {
   this.abstractModelInterface_ = buildAbstractModelInterface_(this);
 
   // Process the existing/past states.
-  this.processStates_(dataLayer, !opt_listenToPast);
+  this.processStates_(dataLayer, !optListenToPast);
 
   // Add listener for future state changes.
   var oldPush = dataLayer.push;

--- a/src/plain/is_plain_object.js
+++ b/src/plain/is_plain_object.js
@@ -16,7 +16,7 @@ goog.module('plain');
 
 /**
  * Pattern used by plain.type to match [object XXX] strings.
- * @type {RegExp}
+ * @type {!RegExp}
  * @private
  * @const
  */
@@ -47,7 +47,7 @@ const TYPE_RE_ =
  */
 function type(value) {
   if (value == null) return String(value);
-  var match = TYPE_RE_.exec(
+  const match = TYPE_RE_.exec(
       Object.prototype.toString.call(Object(value)));
   if (match) return match[1].toLowerCase();
   return 'object';
@@ -75,9 +75,9 @@ function hasOwn(value, key) {
  * @return {boolean} True iff the given value is a "plain" object.
  */
 function isPlainObject(value) {
-  if (!value || type(value) != 'object' ||    // Nulls, dates, etc.
-      value.nodeType ||                             // DOM nodes.
-      value == value.window) {                      // Window objects.
+  if (!value || type(value) != 'object' || // Nulls, dates, etc.
+      value.nodeType || // DOM nodes.
+      value == value.window) { // Window objects.
     return false;
   }
   try {
@@ -97,7 +97,7 @@ function isPlainObject(value) {
   // Lastly, we check that all properties are non-inherited.
   // According to jQuery, inherited properties are always enumerated last, so
   // it's safe to only check the last enumerated property.
-  var key;
+  let key;
   for (key in value) {}
   return key === undefined || hasOwn(value, key);
 }


### PR DESCRIPTION
- Fix compiler warnings around types (nullability, expected vs. received)
- Enforce column limit (except helper.js line 62 which will be handled in PR #35)
- Change to const and lets
- Change to method shorthands
- Use default parameters