### PR TITLE
Updated HasOwn tests

### DIFF
--- a/test/hasOwn_test.js
+++ b/test/hasOwn_test.js
@@ -52,8 +52,6 @@ describe('the hasOwn method', function() {
 
   it('recognizes function properties', () => {
     const fn = () => {};
-    assertHasOwn(fn, 'caller', true);
-    assertHasOwn(fn, 'arguments', true);
     assertHasOwn(fn, 'constructor', false);
     assertHasOwn(fn, 'valueOf', false);
   });


### PR DESCRIPTION
caller and arguments function properties no longer have standard support, so the deleted tests were causing inconsistencies.
![Screenshot 2020-07-08 at 11 03 19 AM](https://user-images.githubusercontent.com/48192017/86942546-dd9b5600-c10a-11ea-9842-ce1dfdd1591e.png)
