### PR TITLE
Fix failing integration tests

### DIFF
--- a/test/integration/integration_test.js
+++ b/test/integration/integration_test.js
@@ -44,8 +44,8 @@ describe('The data layer helper library', () => {
      * so far.
      */
     function assertCallback(expected, numberOfCalls) {
-      expect(callbackListener.calls).toBe(numberOfCalls);
-      expect(callbackListener.calls.mostRecent()).toEqual(expected);
+      expect(callbackListener.calls.count()).toBe(numberOfCalls);
+      expect(callbackListener.calls.mostRecent().args).toEqual(expected);
     }
 
     beforeEach(() => {


### PR DESCRIPTION
PR #46 had some changes which were not tested (I ran the unit tests instead of integration), so the tests started to fail. This fixes it.