### PR TITLE
Publish only src and dist folders

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     "integration": "karma start test/integration/karma.conf.js"
   },
   "main": "dist/data-layer-helper.js",
+  "files": [
+    "/dist",
+    "/src"
+  ],
   "//": "Contributors are listed in alphabetical order by last name. Add yourself!",
   "contributors": [
     "Sam Calhoun <calhounsm@google.com>",


### PR DESCRIPTION
When we run npm publish, we don't want to publish the test files or misc files like .eslintrc.json. This PR ensures that only files that will be used by the user will be published