### PR TITLE
Move build dependencies into devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "eslint-config-closure-es6": "~0.1.1",
     "eslint-config-google": "~0.14.0",
     "eslint-plugin-jasmine": "~4.1.1",
+    "google-closure-compiler": "~20200719.0.0",
+    "google-closure-library": "~20200628.0.0",
     "grunt": "~1.2.1",
     "grunt-closure-tools": "~1.0.0",
     "grunt-karma": "~4.0.0",
@@ -46,10 +48,6 @@
     "karma-jasmine-html-reporter": "~1.5.4",
     "karma-safari-launcher": "~1.0.0",
     "karma-spec-reporter": "~0.0.32"
-  },
-  "dependencies": {
-    "google-closure-compiler": "~20200719.0.0",
-    "google-closure-library": "~20200628.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This moves dependencies that appear to only be used by the build process into `devDependencies`.