### PR TITLE
Empty command arrays pushes fix

### DIFF
--- a/src/helper/data-layer-helper.js
+++ b/src/helper/data-layer-helper.js
@@ -416,6 +416,7 @@ function processCommand_(command, model) {
         `argument must be of type string, but was of type ` +
         `${typeof command[0]}.\nThe command run was ${command}`,
         LogLevel.WARNING);
+        return;
   }
   const path = command[0].split('.');
   const method = path.pop();


### PR DESCRIPTION
Sending an empty command array, makes the library to throw an error since it's tries to make an split of a non-string value. 

Added a proper return statement after checking for a string to prevent the processCommand to continue it's execution.

How to test
-------------
```
window.dataLayer = window.dataLayer || [];
dataLayer.push([]);
const helper = new DataLayerHelper(dataLayer);
```
Error:
-------
```
empty.html:formatted:131 Uncaught TypeError: Cannot read property 'split' of undefined
    at v (empty.html:formatted:131)
    at r.process (empty.html:formatted:96)
    at new r (empty.html:formatted:86)
    at empty.html:formatted:201
v @ empty.html:formatted:131
r.process @ empty.html:formatted:96
r @ empty.html:formatted:86
(anonymous) @ empty.html:formatted:201
empty.html:formatted:131 Uncaught TypeError: Cannot read property 'split' of undefined
    at v (empty.html:formatted:131)
    at r.process (empty.html:formatted:96)
    at new r (empty.html:formatted:86)
    at <anonymous>:481:51
    at Array.forEach (<anonymous>)
    at Object.addListeners (<anonymous>:462:53)
    at <anonymous>:634:28
    at set (<anonymous>:193:30)
    at Yf (gtm.js?id=GTM-XXXX:418)
    at Ap (gtm.js?id=GTM-XXXX:535)
```
