### PR TITLE
fix: guard processCommand of malformed commands

### DIFF
--- a/src/helper/data-layer-helper.js
+++ b/src/helper/data-layer-helper.js
@@ -416,6 +416,7 @@ function processCommand_(command, model) {
         `argument must be of type string, but was of type ` +
         `${typeof command[0]}.\nThe command run was ${command}`,
         LogLevel.WARNING);
+    return;
   }
   const path = command[0].split('.');
   const method = path.pop();


### PR DESCRIPTION
Seems like the `return` was forgotten on some refactor, [v0.1.0 used to have it](https://github.com/google/data-layer-helper/blob/v0.1.0/src/helper/helper.js#L243).